### PR TITLE
simplify/clean up, support release mode in rust

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -1,6 +1,13 @@
 # public variables that can be changed by projects
 BUILD_DIR ?= .build
 CONFIG_DIR ?= .config
+BUILD_MODE ?= debug
+
+# Allow recursive builds (e.g., inside a docker container) by setting this to some
+# other value in the child makefile.  When you want to actually run the build command,
+# set back to local in the make command
+DISPATCH_MODE ?= local
+
 
 # _DEFAULT_BUILD_TARGETS can be modified by sub-makefiles to add additional "default" behaviour
 # when you run `make`


### PR DESCRIPTION
## Related Links
- https://linear.app/acrl/issue/SK-43/update-to-latest-cargo-workspaces-so-we-dont-need-the-allow-dirty-flag
- https://linear.app/acrl/issue/SK-13/make-it-easier-to-build-debug-or-release-variants

## Description and Rationale
- support debug or release builds with the `BUILD_MODE` make variable
  - requires a bunch of text-munging on the CARGO_PROFILE variable, because cargo puts artifacts for the `dev` profile in `.build/debug`, but it puts artifacts for every other profile in `.build/<profile-name>`; if `--artifact-dir` ever stabilizes (https://github.com/rust-lang/cargo/issues/6790), we can get rid of some of this.
- improve a bunch of organization in the Makefiles:
  - create a DISPATCH_MODE which lets the user control how the `build` target is executed: if it's set to `local`, it just runs the build, if it's set to something else (e.g., `recurse`) it runs `make $(BUILD_TARGETS)`, which allows the user to define custom build targets that, e.g., might be executed in a docker container.  The user can then set `DISPATCH_MODE=local` inside those custom targets to execute the actual build.
    - it would be kindof nice if this could be controlled in the `base.mk` include instead of the platform-specific makefile, but I've bikeshedded on this too long already
  - I convert `test` and `build` to `_test` and `_build`, respectively, which better-follows the guidance that underscore targets are supposed to be "internal" and non-underscore targets are supposed to be user-customizable/overrideable.  It's still actually not clear to me if this is the "right"/"good" pattern but it seems to work for now.
  - I use environment variables to pass around `CARGO_HOME` instead of having to create a custom command via the `$(CARGO)` variable
  - Get rid of the `--allow-dirty` flag in `cargo ws publish`, since this is supposedly fixed (see https://github.com/pksunkara/cargo-workspaces/issues/189) (haven't had a chance to test this empirically yet)

## Test Steps
- Tested all the various SimKube combinations: `make build`, `make test`, make a change in the editor and then re-`make build`, they all work and don't cause spurious re-builds
- Tested with skimmer to confirm that for a "simple"/"regular" rust repo this also works correctly
- Confirmed (for both) that debug and release modes build correctly by setting the `BUILD_MODE` arg.

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- it would be sortof nice if the `base.mk` was the thing that supported the dispatch mode, but I tried to do it and it didn't work and I've already spent too much time on this, so whatever.