### PR TITLE
ACRL-417 // Remove tomlq, use awk to parse version

### DIFF
--- a/k8s.mk
+++ b/k8s.mk
@@ -2,11 +2,15 @@ K8S_INPUT_DIR ?= k8s
 K8S_MANIFESTS_DIR ?= $(BUILD_DIR)/manifests
 KUSTOMIZE_DIR ?= kustomize
 
-APP_VERSION=$(shell tomlq -r .workspace.package.version Cargo.toml)
+APP_VERSION := $(shell awk -F'"' '/^version = / {print $$2; exit}' Cargo.toml)
 _DEFAULT_BUILD_TARGETS += run
 
 $(K8S_MANIFESTS_DIR):
 	mkdir -p $@
+
+ifndef APP_VERSION
+$(error APP_VERSION could not be determined from Cargo.toml)
+endif
 
 .PHONY: _k8s
 _k8s:: | $(K8S_MANIFESTS_DIR)


### PR DESCRIPTION
## Related Links
<!-- include a link to the issue(s) this resolves and/or any related design docs -->
- https://linear.app/acrl/issue/ACRL-417/remove-tomlq-dependency-from-build-scripts

## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- Ran into a silent error when `tomlq` is not installed on the machine
- Caused some mild but confusing errors in the SimKube repo when trying to regenerate templated kustomize files via our `make kustomize` target
- I think we can just use `awk` to parse the version from `Cargo.toml` instead of using an additional dependency

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
- remove the tomlq call and substitute an awk command
- add a basic guard if the APP_VERSION cannot be identified, this will prevent future silent failures

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- I tested it manually invoking it in the shell and via the makefile (on SimKube branch I was working on)

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- If you would prefer we keep tomlq I could just document it somewhere

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
